### PR TITLE
Add latency per queue and class.

### DIFF
--- a/lib/librato-sidekiq/client_middleware.rb
+++ b/lib/librato-sidekiq/client_middleware.rb
@@ -13,7 +13,7 @@ module Librato
 
       protected
 
-      def track(tracking_group, stats, worker_instance, msg, queue, elapsed)
+      def track(tracking_group, stats, worker_instance, msg, queue, elapsed, _latency)
         tracking_group.increment 'queued'
         return unless allowed_to_submit queue, worker_instance
         # puts "doing Librato insert"

--- a/lib/librato-sidekiq/middleware.rb
+++ b/lib/librato-sidekiq/middleware.rb
@@ -62,12 +62,8 @@ module Librato
         return result unless enabled
         # puts "#{worker_instance} #{queue}"
 
-        # From the docs (https://github.com/mperham/sidekiq/wiki/Job-Format):
-        # Note that enqueued_at isn't added to the payload for scheduled jobs.
-        # They get the enqueued_at field when they are pushed onto a queue.
-        enqueued_at = msg['enqueued_at'] || start_time
-        latency = (start_time - enqueued_at).to_f
-
+        enqueued_at = msg['enqueued_at']
+        latency = enqueued_at ? start_time.to_f - enqueued_at : nil
         stats = ::Sidekiq::Stats.new
 
         Librato.group 'sidekiq' do |sidekiq|
@@ -85,7 +81,7 @@ module Librato
         # puts "doing Librato insert"
         tracking_group.group queue.to_s do |q|
           q.increment 'processed'
-          q.timing 'latency', latency
+          q.timing 'latency', latency if latency
           q.timing 'time', elapsed
           q.measure 'enqueued', stats.queues[queue].to_i
 
@@ -93,7 +89,7 @@ module Librato
           # a class name with slashes. remove them in favor of underscores
           q.group msg['class'].underscore.gsub('/', '_') do |w|
             w.increment 'processed'
-            w.timing 'latency', latency
+            w.timing 'latency', latency if latency
             w.timing 'time', elapsed
           end
         end

--- a/lib/librato-sidekiq/version.rb
+++ b/lib/librato-sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Librato
   module Sidekiq
-    VERSION = "0.1.3"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
The title is self-explanatory, the only thing to note is that, if `enqueued_at` is not present for some reason (apparently it can be missing for scheduled jobs, the ones where we call `.perform_in`), I consider it was enqueued at the same time it started, which will result in a latency of 0. I think that's fine?

Given this is not a bug fix but a new feature of the gem, I bumped it from `0.1.3` to `0.2.0`.