### PR TITLE
Configure client middleware on the server too

### DIFF
--- a/lib/librato-sidekiq/client_middleware.rb
+++ b/lib/librato-sidekiq/client_middleware.rb
@@ -2,13 +2,16 @@ module Librato
   module Sidekiq
     class ClientMiddleware < Middleware
       def self.reconfigure
-        # puts "Reconfiguring with: #{options}"
-        ::Sidekiq.configure_client do |config|
+        client_configuration = Proc.new do |config|
           config.client_middleware do |chain|
             chain.remove self
             chain.add self, options
           end
         end
+        # puts "Reconfiguring with: #{options}"
+        ::Sidekiq.configure_client(&client_configuration)
+        # Add to the client used on the server too (so jobs enqueued by other jobs get metrics, not just those enqueued by the app)
+        ::Sidekiq.configure_server(&client_configuration)
       end
 
       protected

--- a/spec/unit/client_middleware_spec.rb
+++ b/spec/unit/client_middleware_spec.rb
@@ -46,13 +46,26 @@ describe Librato::Sidekiq::ClientMiddleware do
     let(:chain) { double() }
     let(:config) { double() }
 
-    it 'should add itself to the server middleware chain' do
+    it 'should add itself to the client middleware chain' do
+      allow(Sidekiq).to receive(:configure_server)
       expect(chain).to receive(:remove).with Librato::Sidekiq::ClientMiddleware
       expect(chain).to receive(:add).with Librato::Sidekiq::ClientMiddleware,
                                           described_class.options
 
       expect(config).to receive(:client_middleware).once.and_yield(chain)
       expect(Sidekiq).to receive(:configure_client).once.and_yield(config)
+
+      described_class.reconfigure
+    end
+
+    it 'should add itself to the client middleware chain for the server' do
+      allow(Sidekiq).to receive(:configure_client)
+      expect(chain).to receive(:remove).with Librato::Sidekiq::ClientMiddleware
+      expect(chain).to receive(:add).with Librato::Sidekiq::ClientMiddleware,
+                                          described_class.options
+
+      expect(config).to receive(:client_middleware).once.and_yield(chain)
+      expect(Sidekiq).to receive(:configure_server).once.and_yield(config)
 
       described_class.reconfigure
     end


### PR DESCRIPTION
The sidekiq server is also a client of itself because jobs can enqueue
other jobs.  If we want these kinds of jobs to get the metrics recorded
by the client middleware, we need to configure the client-on-the-server
as well as the client-not-on-the-server to include the middleware.  This
is a little bit confusing, so see [the sidekiq wiki entry on configuring
middleware][middleware-wiki-entry] for more detail.

[middleware-wiki-entry]: https://github.com/mperham/sidekiq/wiki/Middleware#client-middleware-registered-in-both-places