### PR TITLE
Feature faster stats

### DIFF
--- a/lib/librato-sidekiq.rb
+++ b/lib/librato-sidekiq.rb
@@ -1,5 +1,6 @@
 require 'librato-sidekiq/middleware'
 require 'librato-sidekiq/client_middleware'
+require 'librato-sidekiq/stats'
 
 Librato::Sidekiq::Middleware.configure
 Librato::Sidekiq::ClientMiddleware.configure

--- a/lib/librato-sidekiq/client_middleware.rb
+++ b/lib/librato-sidekiq/client_middleware.rb
@@ -16,9 +16,10 @@ module Librato
 
       protected
 
-      def track(tracking_group, stats, worker_instance, msg, queue, elapsed, _latency)
+      def track(tracking_group, _stats, worker_instance, msg, queue, _elapsed, _latency)
         tracking_group.increment 'queued'
         return unless allowed_to_submit queue, worker_instance
+
         # puts "doing Librato insert"
         tracking_group.group queue.to_s do |q|
           q.increment 'queued'

--- a/lib/librato-sidekiq/middleware.rb
+++ b/lib/librato-sidekiq/middleware.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/class/attribute_accessors'
+require_relative 'stats'
 
 module Librato
   module Sidekiq
@@ -64,7 +65,7 @@ module Librato
 
         enqueued_at = msg['enqueued_at']
         latency = enqueued_at ? start_time.to_f - enqueued_at : nil
-        stats = ::Sidekiq::Stats.new
+        stats = ::Librato::Sidekiq::Stats.new
 
         Librato.group 'sidekiq' do |sidekiq|
           track sidekiq, stats, worker_instance, msg, queue, elapsed, latency

--- a/lib/librato-sidekiq/stats.rb
+++ b/lib/librato-sidekiq/stats.rb
@@ -1,0 +1,118 @@
+# https://github.com/mperham/sidekiq/blob/v6.2.1/lib/sidekiq/api.rb#L8-L147
+require 'sidekiq'
+
+module Librato
+  module Sidekiq
+    class Stats
+      def initialize
+        fetch_stats!
+      end
+
+      def processed
+        stat :processed
+      end
+
+      def failed
+        stat :failed
+      end
+
+      def scheduled_size
+        stat :scheduled_size
+      end
+
+      def retry_size
+        stat :retry_size
+      end
+
+      def dead_size
+        stat :dead_size
+      end
+
+      def enqueued
+        stat :enqueued
+      end
+
+      def processes_size
+        stat :processes_size
+      end
+
+      def default_queue_latency
+        stat :default_queue_latency
+      end
+
+      def queues
+        ::Sidekiq::Stats::Queues.new.lengths
+      end
+
+      def fetch_stats!
+        pipe1_res = ::Sidekiq.redis { |conn|
+          conn.pipelined do
+            conn.get("stat:processed")
+            conn.get("stat:failed")
+            conn.zcard("schedule")
+            conn.zcard("retry")
+            conn.zcard("dead")
+            conn.scard("processes")
+            conn.lrange("queue:default", -1, -1)
+          end
+        }
+
+        queues = ::Sidekiq.redis { |conn|
+          conn.sscan_each("queues").to_a
+        }
+
+        pipe2_res = ::Sidekiq.redis { |conn|
+          conn.pipelined do
+            queues.each { |queue| conn.llen("queue:#{queue}") }
+          end
+        }
+
+        enqueued = pipe2_res.sum(&:to_i)
+
+        default_queue_latency = if (entry = pipe1_res[6].first)
+                                  job = begin
+                                          ::Sidekiq.load_json(entry)
+                                        rescue
+                                          {}
+                                        end
+                                  now = Time.now.to_f
+                                  thence = job["enqueued_at"] || now
+                                  now - thence
+                                else
+                                  0
+                                end
+        @stats = {
+          processed: pipe1_res[0].to_i,
+          failed: pipe1_res[1].to_i,
+          scheduled_size: pipe1_res[2],
+          retry_size: pipe1_res[3],
+          dead_size: pipe1_res[4],
+          processes_size: pipe1_res[5],
+
+          default_queue_latency: default_queue_latency,
+          enqueued: enqueued
+        }
+      end
+
+      def reset(*stats)
+        all = %w[failed processed]
+        stats = stats.empty? ? all : all & stats.flatten.compact.map(&:to_s)
+
+        mset_args = []
+        stats.each do |stat|
+          mset_args << "stat:#{stat}"
+          mset_args << 0
+        end
+        ::Sidekiq.redis do |conn|
+          conn.mset(*mset_args)
+        end
+      end
+
+      private
+
+      def stat(s)
+        @stats[s]
+      end
+    end
+  end
+end

--- a/lib/librato-sidekiq/version.rb
+++ b/lib/librato-sidekiq/version.rb
@@ -1,5 +1,5 @@
 module Librato
   module Sidekiq
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/spec/unit/client_middleware_spec.rb
+++ b/spec/unit/client_middleware_spec.rb
@@ -5,7 +5,7 @@ describe Librato::Sidekiq::ClientMiddleware do
   before(:each) do
     stub_const "Librato::Rails", Class.new
     stub_const "Sidekiq", Module.new
-    stub_const "Sidekiq::Stats", Class.new
+    stub_const "Librato::Sidekiq::Stats", Class.new
   end
 
   let(:middleware) do
@@ -80,7 +80,7 @@ describe Librato::Sidekiq::ClientMiddleware do
     let(:some_message) { Hash['class', double(underscore: queue_name)] }
 
     let(:sidekiq_stats_instance_double) do
-      double("Sidekiq::Stats", :enqueued => 1, :failed => 2, :scheduled_size => 3)
+      double("Librato::Sidekiq::Stats", :enqueued => 1, :failed => 2, :scheduled_size => 3)
     end
 
     context 'when middleware is not enabled' do
@@ -98,7 +98,7 @@ describe Librato::Sidekiq::ClientMiddleware do
     context 'when middleware is enabled but queue is blacklisted' do
 
       before(:each) do
-        allow(Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
+        allow(Librato::Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
         allow(Librato).to receive(:group).with('sidekiq').and_yield meter
       end
 
@@ -129,7 +129,7 @@ describe Librato::Sidekiq::ClientMiddleware do
       end
 
       before(:each) do
-        allow(Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
+        allow(Librato::Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
         allow(Librato).to receive(:group).with('sidekiq').and_yield(sidekiq_group)
         allow(sidekiq_stats_instance_double).to receive(:queues)
       end

--- a/spec/unit/middleware_spec.rb
+++ b/spec/unit/middleware_spec.rb
@@ -5,7 +5,7 @@ describe Librato::Sidekiq::Middleware do
   before(:each) do
     stub_const "Librato::Rails", Class.new
     stub_const "Sidekiq", Module.new
-    stub_const "Sidekiq::Stats", Class.new
+    stub_const "Librato::Sidekiq::Stats", Class.new
   end
 
   let(:middleware) do
@@ -68,7 +68,7 @@ describe Librato::Sidekiq::Middleware do
     let(:some_message) { Hash['class', double(underscore: queue_name), 'enqueued_at', (Time.now - latency_seconds).to_f] }
 
     let(:sidekiq_stats_instance_double) do
-      double("Sidekiq::Stats", :enqueued => 1, :failed => 2, :scheduled_size => 3)
+      double("Librato::Sidekiq::Stats", :enqueued => 1, :failed => 2, :scheduled_size => 3)
     end
 
     context 'when middleware is not enabled' do
@@ -86,7 +86,7 @@ describe Librato::Sidekiq::Middleware do
     context 'when middleware is enabled but queue is blacklisted' do
 
       before(:each) do
-        allow(Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
+        allow(Librato::Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
         allow(Librato).to receive(:group).with('sidekiq').and_yield meter
       end
 
@@ -128,7 +128,7 @@ describe Librato::Sidekiq::Middleware do
       end
 
       before(:each) do
-        allow(Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
+        allow(Librato::Sidekiq::Stats).to receive(:new).and_return(sidekiq_stats_instance_double)
         allow(Librato).to receive(:group).with('sidekiq').and_yield(sidekiq_group)
         allow(sidekiq_stats_instance_double).to receive(:queues).and_return queue_stat_hash
       end


### PR DESCRIPTION
This gem calls `Sidekiq::Stats.new` on each enqueue (and on each process.) This makes O(number_of_processes) redis calls. This is bad. This Pr stops it doing that.